### PR TITLE
Include saved data in jsPsych export for resumed sessions

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -40,6 +40,7 @@ const jsPsych = initJsPsych({
 // 2. Prepare the timeline
 const participant_id = getParticipantId(jsPsych);
 const saved_data = loadData();
+if (saved_data) { jsPsych.data.addData(saved_data); }
 const completed_trials = saved_data ? saved_data.map(trial => trial.audio_filename) : [];
 const stimuli_to_run = stimuli.filter(stimulus => !completed_trials.includes(stimulus.filename));
 


### PR DESCRIPTION
## Summary
- Preload previously saved jsPsych data before building the timeline so resumed sessions contain earlier trials in the final CSV.

## Testing
- `node --check experiment.js`


------
https://chatgpt.com/codex/tasks/task_e_689689c474948321b6e4d8f5e1dd9cb0