### PR TITLE
Add stylesheet and refactor inline styles for cleaner UI

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -47,7 +47,7 @@ let timeline = [];
 
 if (stimuli_to_run.length > 0) {
   let welcome_message = `
-    <div style="max-width: 600px; text-align: left; line-height: 1.6em;">
+    <div class="content">
       <h2>Welcome to the Survey</h2>
       <p>Your task is to decide if the sentence you read matches what was said in the audio.</p>
       <p>Your progress is saved automatically, so you can close the tab and return later to continue.</p>
@@ -55,7 +55,7 @@ if (stimuli_to_run.length > 0) {
   `;
   if (saved_data && completed_trials.length > 0) {
     welcome_message = `
-      <div style="max-width: 600px; text-align: left; line-height: 1.6em;">
+      <div class="content">
         <h2>Welcome Back!</h2>
         <p>You have completed ${completed_trials.length} out of ${stimuli.length} questions.</p>
         <p>We'll start you right where you left off.</p>
@@ -65,8 +65,7 @@ if (stimuli_to_run.length > 0) {
   const instructions = {
     type: jsPsychHtmlButtonResponse, // This will now work correctly
     stimulus: welcome_message,
-    choices: ['Begin'],
-    margin_vertical: '20px'
+    choices: ['Begin']
   };
   timeline.push(instructions);
 
@@ -80,20 +79,20 @@ if (stimuli_to_run.length > 0) {
       const sentence = jsPsych.timelineVariable('sentence');
       const filename = jsPsych.timelineVariable('filename');
       return `
-        <div style="max-width: 600px;">
+        <div class="prompt-container">
           <p>Does the following sentence match what you heard in the audio: <b>${filename}</b>?</p>
-          <p style="font-size: 1.2em; font-style: italic; color: #333; border: 1px solid #ccc; padding: 15px; border-radius: 8px;">
+          <p class="prompt-sentence">
             "${sentence}"
           </p>
         </div>
       `;
     },
-    trial_starts_message: '<p style="font-size: 1.2em;">Loading next audio...</p>',
+    trial_starts_message: '<p class="loading-message">Loading next audio...</p>',
     data: {
       participant_id: participant_id,
       task: 'audio-match',
       sentence: jsPsych.timelineVariable('sentence'),
-      audio_filename: jsPsych.timelineVariable('filename') 
+      audio_filename: jsPsych.timelineVariable('filename')
     }
   };
   timeline.push(main_trials);
@@ -102,14 +101,13 @@ if (stimuli_to_run.length > 0) {
 const end_screen = {
   type: jsPsychHtmlButtonResponse,
   stimulus: `
-    <div style="max-width: 600px; text-align: left;">
+    <div class="content">
       <h2>Survey Complete!</h2>
       <p>Thank you for your participation.</p>
       <p>If you have finished all questions, the data file will now download automatically. If you see this screen on your first visit, it means you have already completed this survey in this browser.</p>
     </div>
   `,
-  choices: ['Finish'],
-  margin_vertical: '20px'
+  choices: ['Finish']
 };
 timeline.push(end_screen);
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <title>Audio Evaluation Survey</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="jspsych/jspsych.css" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <div id="jspsych-target"></div>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,49 @@
+body {
+  font-family: 'Segoe UI', sans-serif;
+  background-color: #f7f7f7;
+  margin: 0;
+  color: #333;
+}
+
+#jspsych-target {
+  max-width: 800px;
+  margin: 40px auto;
+}
+
+.content {
+  max-width: 600px;
+  text-align: left;
+  line-height: 1.6em;
+}
+
+.prompt-container {
+  max-width: 600px;
+}
+
+.prompt-sentence {
+  font-size: 1.2em;
+  font-style: italic;
+  color: #333;
+  border: 1px solid #ccc;
+  padding: 15px;
+  border-radius: 8px;
+}
+
+.loading-message {
+  font-size: 1.2em;
+}
+
+.jspsych-btn {
+  padding: 10px 20px;
+  margin: 10px 5px;
+  background-color: #0069d9;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}
+
+.jspsych-btn:hover {
+  background-color: #0053ba;
+}
+


### PR DESCRIPTION
## Summary
- Add global `style.css` with modern font, subtle background, centered experiment container, and custom button styling
- Link new stylesheet in `index.html`
- Replace inline styles in `experiment.js` with CSS classes for cleaner prompts and messages

## Testing
- `node --check experiment.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689689c82f288321a445ef7b6d3bf0a4