### PR TITLE
Handle loading message via callbacks

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -34,8 +34,15 @@ const jsPsych = initJsPsych({
     localStorage.removeItem(STORAGE_KEY + '_pid');
   },
   // We need to tell jsPsych where our target div is
-  display_element: 'jspsych-target' 
+  display_element: 'jspsych-target'
 });
+
+// Custom loading message element
+const loadingMessage = document.createElement('div');
+loadingMessage.id = 'loading-message';
+loadingMessage.innerHTML = '<p style="font-size: 1.2em;">Loading next audio...</p>';
+loadingMessage.style.display = 'none';
+document.body.appendChild(loadingMessage);
 
 // 2. Prepare the timeline
 const participant_id = getParticipantId(jsPsych);
@@ -88,12 +95,19 @@ if (stimuli_to_run.length > 0) {
         </div>
       `;
     },
-    trial_starts_message: '<p style="font-size: 1.2em;">Loading next audio...</p>',
+    on_start: () => {
+      const msg = document.getElementById('loading-message');
+      if (msg) msg.style.display = 'block';
+    },
+    on_load: () => {
+      const msg = document.getElementById('loading-message');
+      if (msg) msg.style.display = 'none';
+    },
     data: {
       participant_id: participant_id,
       task: 'audio-match',
       sentence: jsPsych.timelineVariable('sentence'),
-      audio_filename: jsPsych.timelineVariable('filename') 
+      audio_filename: jsPsych.timelineVariable('filename')
     }
   };
   timeline.push(main_trials);


### PR DESCRIPTION
## Summary
- remove unused `trial_starts_message` option from main_trials
- show and hide custom loading message using `on_start` and `on_load` callbacks

## Testing
- `node --check experiment.js`


------
https://chatgpt.com/codex/tasks/task_e_689689c4fc608321bb388090564fc5ba