### PR TITLE
Refactor main trials to use timeline

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -71,31 +71,29 @@ if (stimuli_to_run.length > 0) {
   timeline.push(instructions);
 
   const main_trials = {
-    type: jsPsychAudioButtonResponse, // This will now work correctly
+    timeline: [{
+      type: jsPsychAudioButtonResponse,
+      stimulus: jsPsych.timelineVariable('audio'),
+      choices: ['Yes', 'No', 'Not Sure'],
+      prompt: () => {
+        const sentence = jsPsych.timelineVariable('sentence');
+        const filename = jsPsych.timelineVariable('filename');
+        return `<div class="prompt-container">
+                  <p>Does the following sentence match what you heard in the audio: <b>${filename}</b>?</p>
+                  <p class="prompt-sentence">"${sentence}"</p>
+                </div>`;
+      },
+      data: {
+        participant_id: participant_id,
+        task: 'audio-match',
+        sentence: jsPsych.timelineVariable('sentence'),
+        audio_filename: jsPsych.timelineVariable('filename')
+      }
+    }],
     timeline_variables: stimuli_to_run,
-    randomize_order: true,
-    stimulus: jsPsych.timelineVariable('audio'),
-    choices: ['Yes', 'No', 'Not Sure'],
-    prompt: () => {
-      const sentence = jsPsych.timelineVariable('sentence');
-      const filename = jsPsych.timelineVariable('filename');
-      return `
-        <div class="prompt-container">
-          <p>Does the following sentence match what you heard in the audio: <b>${filename}</b>?</p>
-          <p class="prompt-sentence">
-            "${sentence}"
-          </p>
-        </div>
-      `;
-    },
-    trial_starts_message: '<p class="loading-message">Loading next audio...</p>',
-    data: {
-      participant_id: participant_id,
-      task: 'audio-match',
-      sentence: jsPsych.timelineVariable('sentence'),
-      audio_filename: jsPsych.timelineVariable('filename')
-    }
+    randomize_order: true
   };
+
   timeline.push(main_trials);
 }
 


### PR DESCRIPTION
## Summary
- Restructure main trials to use a nested timeline with per-trial audio prompts and data tags
- Insert main trials into experiment timeline after instructions

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check experiment.js`


------
https://chatgpt.com/codex/tasks/task_e_68968dc167e08321854b4035cd0c0ef2