### PR TITLE
Use callback to show loading message for audio trials

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -88,7 +88,18 @@ if (stimuli_to_run.length > 0) {
         </div>
       `;
     },
-    trial_starts_message: '<p class="loading-message">Loading next audio...</p>',
+    on_start: function() {
+      const container = document.querySelector('#jspsych-target');
+      if (container) {
+        container.insertAdjacentHTML('beforeend', '<p class="loading-message">Loading next audio...</p>');
+      }
+    },
+    on_load: function() {
+      const message = document.querySelector('#jspsych-target .loading-message');
+      if (message) {
+        message.remove();
+      }
+    },
     data: {
       participant_id: participant_id,
       task: 'audio-match',


### PR DESCRIPTION
## Summary
- Remove `trial_starts_message` from audio trial configuration
- Inject and clean up custom "Loading next audio" message using `on_start`/`on_load`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968dc26a6c8321b1ed06e01c0fd83f