### PR TITLE
Preload audio stimuli using jsPsych preload plugin

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -46,6 +46,12 @@ const stimuli_to_run = stimuli.filter(stimulus => !completed_trials.includes(sti
 
 let timeline = [];
 
+const preload = {
+  type: jsPsychPreload,
+  audio: stimuli_to_run.map(s => s.audio)
+};
+timeline.unshift(preload);
+
 if (stimuli_to_run.length > 0) {
   let welcome_message = `
     <div class="content">

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="jspsych-target"></div>
 
     <script src="jspsych/jspsych.js"></script>
+    <script src="jspsych/plugin-preload.js"></script>
     <script src="jspsych/plugin-html-button-response.js"></script>
     <script src="jspsych/plugin-audio-button-response.js"></script>
     <script src="stimuli.js"></script>


### PR DESCRIPTION
## Summary
- Preload audio files before running the experiment timeline
- Reference jsPsych preload plugin in index.html

## Testing
- `node --check experiment.js`


------
https://chatgpt.com/codex/tasks/task_e_68968dc54fe08321b735d4fcbbdc21e0