### PR TITLE
Add manual audio player with navigation controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,13 @@
   <head>
     <title>Audio Evaluation Survey</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="jspsych/jspsych.css" rel="stylesheet" type="text/css" />
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <div id="jspsych-target"></div>
+    <div id="player-container"></div>
 
-    <script src="jspsych/jspsych.js"></script>
-    <script src="jspsych/plugin-preload.js"></script>
-    <script src="jspsych/plugin-html-button-response.js"></script>
-    <script src="jspsych/plugin-audio-button-response.js"></script>
     <script src="stimuli.js"></script>
-    <script src="experiment.js"></script>
+    <script src="player.js"></script>
   </body>
 </html>

--- a/player.js
+++ b/player.js
@@ -1,0 +1,88 @@
+// player.js - Custom audio player with next/previous and progress bar
+
+let currentIndex = 0;
+const audio = new Audio();
+audio.preload = 'none';
+
+const container = document.getElementById('player-container');
+container.innerHTML = `
+  <div class="audio-player">
+    <h2 id="audio-title"></h2>
+    <p id="sentence-text" class="prompt-sentence"></p>
+    <div class="controls">
+      <button id="prev-btn" class="control-btn">Previous</button>
+      <button id="play-btn" class="control-btn">Play</button>
+      <button id="next-btn" class="control-btn">Next</button>
+    </div>
+    <div class="progress">
+      <span id="current-time">0:00</span>
+      <input type="range" id="progress-bar" value="0" min="0" max="100" step="0.1">
+      <span id="duration">0:00</span>
+    </div>
+  </div>
+`;
+
+const titleEl = document.getElementById('audio-title');
+const sentenceEl = document.getElementById('sentence-text');
+const playBtn = document.getElementById('play-btn');
+const nextBtn = document.getElementById('next-btn');
+const prevBtn = document.getElementById('prev-btn');
+const progressBar = document.getElementById('progress-bar');
+const currentTimeEl = document.getElementById('current-time');
+const durationEl = document.getElementById('duration');
+
+function loadStimulus(index) {
+  const stim = stimuli[index];
+  audio.src = stim.audio;
+  titleEl.textContent = stim.filename;
+  sentenceEl.textContent = `"${stim.sentence}"`;
+  progressBar.value = 0;
+  currentTimeEl.textContent = '0:00';
+  durationEl.textContent = '0:00';
+}
+
+function formatTime(sec) {
+  if (isNaN(sec)) return '0:00';
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+playBtn.addEventListener('click', () => {
+  if (audio.paused) {
+    audio.play();
+    playBtn.textContent = 'Pause';
+  } else {
+    audio.pause();
+    playBtn.textContent = 'Play';
+  }
+});
+
+nextBtn.addEventListener('click', () => {
+  currentIndex = (currentIndex + 1) % stimuli.length;
+  loadStimulus(currentIndex);
+  audio.pause();
+  playBtn.textContent = 'Play';
+});
+
+prevBtn.addEventListener('click', () => {
+  currentIndex = (currentIndex - 1 + stimuli.length) % stimuli.length;
+  loadStimulus(currentIndex);
+  audio.pause();
+  playBtn.textContent = 'Play';
+});
+
+audio.addEventListener('timeupdate', () => {
+  const progress = (audio.currentTime / audio.duration) * 100;
+  progressBar.value = progress;
+  currentTimeEl.textContent = formatTime(audio.currentTime);
+  durationEl.textContent = formatTime(audio.duration);
+});
+
+progressBar.addEventListener('input', () => {
+  const time = (progressBar.value / 100) * audio.duration;
+  audio.currentTime = time;
+});
+
+loadStimulus(currentIndex);
+

--- a/style.css
+++ b/style.css
@@ -5,19 +5,48 @@ body {
   color: #333;
 }
 
-#jspsych-target {
+.audio-player {
+  max-width: 600px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.controls {
+  margin-top: 10px;
+}
+
+.control-btn {
+  padding: 10px 15px;
+  margin: 0 5px;
+  background-color: #0069d9;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}
+
+.control-btn:hover {
+  background-color: #0053ba;
+}
+
+.progress {
+  display: flex;
+  align-items: center;
+  margin-top: 15px;
+}
+
+.progress input[type="range"] {
+  flex: 1;
+  margin: 0 10px;
+}
+
+#player-container {
   max-width: 800px;
   margin: 40px auto;
-}
-
-.content {
-  max-width: 600px;
-  text-align: left;
-  line-height: 1.6em;
-}
-
-.prompt-container {
-  max-width: 600px;
 }
 
 .prompt-sentence {
@@ -28,22 +57,3 @@ body {
   padding: 15px;
   border-radius: 8px;
 }
-
-.loading-message {
-  font-size: 1.2em;
-}
-
-.jspsych-btn {
-  padding: 10px 20px;
-  margin: 10px 5px;
-  background-color: #0069d9;
-  border: none;
-  border-radius: 4px;
-  color: #fff;
-  cursor: pointer;
-}
-
-.jspsych-btn:hover {
-  background-color: #0053ba;
-}
-


### PR DESCRIPTION
## Summary
- Replace jsPsych interface with custom audio player
- Provide Play, Next, and Previous controls plus progress bar
- Display audio titles and sentences clearly and add favicon placeholder

## Testing
- `node --check player.js`


------
https://chatgpt.com/codex/tasks/task_e_689693b83fac8321868866b4e22cd99f