### PR TITLE
Add survey progress tracking and resume support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,20 @@
     <title>Audio Evaluation Survey</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="jspsych/jspsych.css">
+    <link rel="stylesheet" href="jspsych/survey.css">
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <div id="player-container"></div>
+    <div id="jspsych-target"></div>
 
     <script src="stimuli.js"></script>
-    <script src="player.js"></script>
+    <script src="jspsych/jspsych.js"></script>
+    <script src="jspsych/plugin-preload.js"></script>
+    <script src="jspsych/plugin-html-button-response.js"></script>
+    <script src="jspsych/plugin-audio-button-response.js"></script>
+    <script src="jspsych/plugin-survey-multi-choice.js"></script>
+    <script src="jspsych/plugin-survey-text.js"></script>
+    <script src="experiment.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -57,3 +57,16 @@ body {
   padding: 15px;
   border-radius: 8px;
 }
+
+#jspsych-target {
+  max-width: 800px;
+  margin: 40px auto;
+}
+
+#jspsych-progressbar-outer {
+  width: 100%;
+}
+
+#jspsych-progressbar-inner {
+  background-color: #0069d9;
+}


### PR DESCRIPTION
## Summary
- Show a welcome message and load remaining items when resuming the survey
- Add jsPsych progress bar, final survey questions, and responsive layout for mobile/desktop
- Persist each trial to `/save-progress` so partial data is stored even if the survey is unfinished

## Testing
- `node --check experiment.js`


------
https://chatgpt.com/codex/tasks/task_e_68969727e2b48321bc6bdbbfbea3fa5a