### PR TITLE
Restore manual audio player page

### DIFF
--- a/player.html
+++ b/player.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Audio Player</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <div id="player-container"></div>
+
+    <script src="stimuli.js"></script>
+    <script src="player.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add `player.html` that serves the standalone audio player, ensuring manual preview still works alongside new survey features.

## Testing
- `node --check experiment.js player.js stimuli.js`
- `python3 -m py_compile generate_stimuli.py`
- `python3 generate_stimuli.py`

------
https://chatgpt.com/codex/tasks/task_e_689699ee84b48321854b66cb80bdcd30